### PR TITLE
add a cron for redownloading and checking certdata.txt

### DIFF
--- a/extract_test.go
+++ b/extract_test.go
@@ -2,8 +2,21 @@ package nsscerts
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
+	"net/http"
+	"os"
 	"testing"
+	"time"
+)
+
+var (
+	expectedCertCount = 133
+
+	isTravis = os.Getenv("TRAVIS_OS_NAME") != ""
+	isCron = os.Getenv("TRAVIS_EVENT_TYPE") == "cron"
+
+	maxDownloadSize = int64(10 * 1024 * 1024)
 )
 
 func TestExtractNSS(t *testing.T) {
@@ -18,7 +31,37 @@ func TestExtractNSS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(certs) != 133 {
+	if len(certs) != expectedCertCount {
 		t.Errorf("got %d certs", len(certs))
+	}
+}
+
+// https://docs.travis-ci.com/user/cron-jobs/#Detecting-Builds-Triggered-by-Cron
+func TestExtractNSS_weekly(t *testing.T) {
+	if !isTravis || !isCron {
+		t.Skip("not in travisci cron")
+	}
+
+	client := http.Client{
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Get(LatestDownloadURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
+	r := io.LimitReader(resp.Body, maxDownloadSize)
+
+	// parse
+	certs, err := List(r, &Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(certs) != expectedCertCount {
+		t.Error("got %d certs, expected %d", len(certs), expectedCertCount)
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/adamdecaf/extract-nss-root-certs/issues/3

```
$ TRAVIS_OS_NAME=osx TRAVIS_EVENT_TYPE=cron go test -v ./...
=== RUN   TestExtractNSS
--- PASS: TestExtractNSS (0.03s)
=== RUN   TestExtractNSS_weekly
--- PASS: TestExtractNSS_weekly (2.42s)
PASS
ok  	github.com/adamdecaf/extract-nss-root-certs	2.461s
```